### PR TITLE
fixed common proxy path

### DIFF
--- a/src/main/java/com/henrikstabell/fogworld/FogWorld.java
+++ b/src/main/java/com/henrikstabell/fogworld/FogWorld.java
@@ -19,7 +19,7 @@ public class FogWorld {
     public static final String MODID = "fogworld";
     public static final String VERSION = "@VERSION@";
 
-    @SidedProxy(serverSide = "com.henrikstabell.proxy.CommonProxy", clientSide = "com.henrikstabell.fogworld.proxy.ClientProxy")
+    @SidedProxy(serverSide = "com.henrikstabell.fogworld.proxy.CommonProxy", clientSide = "com.henrikstabell.fogworld.proxy.ClientProxy")
     public static CommonProxy proxy;
 
     public static final DamageSource DAMAGEFOG = new DamageSource("fog");


### PR DESCRIPTION
Hey,

found this little error which caused crashes on the mod initialization (simple "class not found" error).
Fixed it for the use with my private modpack and figured I could quickly create a pull request.
Or you can simply fix it yourself without the PR, I mean it is just one missing word after all :)

Best regards